### PR TITLE
Git: add updated git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,15 @@
-bridges/sqs-twilio/foo.yaml
+# Local configurations and secrets
+/.env/
+/.local/
+
+# Continuous integration
+
+# Editors and IDEs
+*.swo
+*.swp
+*~
+/*.sublime-project
+/*.sublime-workspace
+/.DS_Store
+/.idea/
+/.vscode/


### PR DESCRIPTION
This repo lacks the git ignore entries that we use elsewhere for working with IDEs and OSs.
Adding a very standard version of it.