### PR TITLE
Bridge: add kafka bridges

### DIFF
--- a/bridges/cronjob-confluent/README.md
+++ b/bridges/cronjob-confluent/README.md
@@ -11,7 +11,7 @@ This bridge uses
 - A trigger that connects the broker with the target
 - A Confluent target
 
-## Parametrization
+## Parameterization
 
 Customization of URL and secret creation for Confluent is required.
 

--- a/bridges/cronjob-elastic/README.md
+++ b/bridges/cronjob-elastic/README.md
@@ -11,7 +11,7 @@ This bridge uses
 - A trigger that connects the broker with the target
 - An Elasticsearch target
 
-## Parametrization
+## Parameterization
 
 Customization of URL and secret creation for Elasticsearch is required.
 

--- a/bridges/github-twilio/README.md
+++ b/bridges/github-twilio/README.md
@@ -14,7 +14,7 @@ This bridge uses
 - A trigger that connects the Twilio broker with the target
 - A Twilio target
 
-## Parametrization
+## Parameterization
 
 Customization of GitHub secrets and owner/repo, and Twilio secrets and default numbers are required.
 

--- a/bridges/kafka-display/README.md
+++ b/bridges/kafka-display/README.md
@@ -1,0 +1,16 @@
+# Kafka to event-display service
+
+This sample logs messages sent throught Kafka into an `event-display` service.
+
+## Components
+
+This bridge uses
+
+- Kafka source as the producer of events
+- A broker that receives events from Kafka
+- A trigger that connects the broker with the service
+- An event display service
+
+## Parametrization
+
+Kafka source is a community component, refer to [Kafka repo](https://github.com/knative/eventing-contrib/tree/master/kafka/source) for configuration.

--- a/bridges/kafka-display/README.md
+++ b/bridges/kafka-display/README.md
@@ -1,6 +1,6 @@
 # Kafka to event-display service
 
-This sample logs messages sent throught Kafka into an `event-display` service.
+This sample Bridge logs messages sent throught Kafka into an `event-display` service.
 
 ## Components
 

--- a/bridges/kafka-display/README.md
+++ b/bridges/kafka-display/README.md
@@ -11,6 +11,6 @@ This bridge uses
 - A trigger that connects the broker with the service
 - An event display service
 
-## Parametrization
+## Parameterization
 
 Kafka source is a community component, refer to [Kafka repo](https://github.com/knative/eventing-contrib/tree/master/kafka/source) for configuration.

--- a/bridges/kafka-display/kafka-display.yaml
+++ b/bridges/kafka-display/kafka-display.yaml
@@ -1,0 +1,55 @@
+apiVersion: flow.triggermesh.io/v1alpha1
+kind: Bridge
+metadata:
+  annotations:
+    bridges.triggermesh.io/name: kafka-display
+  name: kafka-display
+spec:
+  components:
+    - object:
+        apiVersion: eventing.knative.dev/v1
+        kind: Broker
+        metadata:
+          name: kafka
+
+    - object:
+        apiVersion: sources.knative.dev/v1beta1
+        kind: KafkaSource
+        metadata:
+          name: kafka-topic1
+        spec:
+          consumerGroup: consumers-group1
+          bootstrapServers:
+          - mycluster-kafka-bootstrap.kafka:9092
+          topics:
+          - mytopic
+          sink:
+            ref:
+              apiVersion: eventing.knative.dev/v1
+              kind: Broker
+              name: kafka
+
+    - object:
+        apiVersion: serving.knative.dev/v1
+        kind: Service
+        metadata:
+          name: event-display
+        spec:
+          template:
+            spec:
+              containers:
+              - image:  gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display@sha256:46d5a66f300c3ced590835d379a0e9badf413ae7ab60f21a2550ecedbc9eb9d3
+                name: user-container
+
+    - object:
+        apiVersion: eventing.knative.dev/v1
+        kind: Trigger
+        metadata:
+          name: kafka-events
+        spec:
+          broker: kafka
+          subscriber:
+            ref:
+              apiVersion: serving.knative.dev/v1
+              kind: Service
+              name: event-display

--- a/bridges/kafka-elasticsearch/README.md
+++ b/bridges/kafka-elasticsearch/README.md
@@ -1,6 +1,6 @@
 # Kafka to Elasticsearch
 
-This sample bridge indexes messages sent throught Kafka into an Elasticsearch cluster.
+This sample Bridge indexes messages sent through Kafka into an Elasticsearch cluster.
 
 ## Components
 

--- a/bridges/kafka-elasticsearch/README.md
+++ b/bridges/kafka-elasticsearch/README.md
@@ -11,7 +11,7 @@ This bridge uses
 - A trigger that connects the broker with the target
 - An Elasticsearch target
 
-## Parametrization
+## Parameterization
 
 Customization of URL parameter and secret for Elasticsearch authentication are required. Kafka source is a community component that  will also need to be configured.
 

--- a/bridges/kafka-elasticsearch/README.md
+++ b/bridges/kafka-elasticsearch/README.md
@@ -1,0 +1,19 @@
+# Kafka to Elasticsearch
+
+This sample bridge indexes messages sent throught Kafka into an Elasticsearch cluster.
+
+## Components
+
+This bridge uses
+
+- Kafka source as the producer of events
+- A broker that receives events from Kafka
+- A trigger that connects the broker with the target
+- An Elasticsearch target
+
+## Parametrization
+
+Customization of URL parameter and secret for Elasticsearch authentication are required. Kafka source is a community component that  will also need to be configured.
+
+- Refer to [Kafka repo](https://github.com/knative/eventing-contrib/tree/master/kafka/source) for configuring the Kafka instance
+- Refer to [Elasticsearch docs](../../docs/targets/elasticsearch.md) for configuring Elasticsearch.

--- a/bridges/kafka-elasticsearch/elasticsearch-secret.yaml
+++ b/bridges/kafka-elasticsearch/elasticsearch-secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: elastic
+type: Opaque
+data:
+  password: <REPLACE_WITH_YOUR_PASSWORD>

--- a/bridges/kafka-elasticsearch/kafka-elasticsearch.yaml
+++ b/bridges/kafka-elasticsearch/kafka-elasticsearch.yaml
@@ -1,0 +1,60 @@
+apiVersion: flow.triggermesh.io/v1alpha1
+kind: Bridge
+metadata:
+  annotations:
+    bridges.triggermesh.io/name: kafka-elasticsearch
+  name: kafka-elasticsearch
+spec:
+  components:
+    - object:
+        apiVersion: eventing.knative.dev/v1
+        kind: Broker
+        metadata:
+          name: kafka
+
+    - object:
+        apiVersion: sources.knative.dev/v1beta1
+        kind: KafkaSource
+        metadata:
+          name: kafka-topic1
+        spec:
+          consumerGroup: consumers-group1
+          bootstrapServers:
+          - mycluster-kafka-bootstrap.kafka:9092
+          topics:
+          - mytopic
+          sink:
+            ref:
+              apiVersion: eventing.knative.dev/v1
+              kind: Broker
+              name: kafka
+
+    - object:
+        apiVersion: targets.triggermesh.io/v1alpha1
+        kind: ElasticsearchTarget
+        metadata:
+          name: tm-elastic
+        spec:
+          connection:
+            addresses:
+              - https://triggermesh-demo-es-http.tm-elastic:9200
+            skipVerify: true
+            username: elastic
+            password:
+              secretKeyRef:
+                key: password
+                name: elastic
+          indexName: tmindex
+
+    - object:
+        apiVersion: eventing.knative.dev/v1
+        kind: Trigger
+        metadata:
+          name: kafka-elasticsearch
+        spec:
+          broker: kafka
+          subscriber:
+            ref:
+              apiVersion: targets.triggermesh.io/v1alpha1
+              kind: ElasticsearchTarget
+              name: tm-elastic

--- a/bridges/kinesis-confluent/README.md
+++ b/bridges/kinesis-confluent/README.md
@@ -11,7 +11,7 @@ This bridge uses
 - A Confluent Target instance.
 - A trigger that connects the broker with the target.
 
-## Parametrization
+## Parameterization
 
 Customization of Confluent's instance is required to provide credentials, servers, topics and connection options. Kinesis source is also customizable to provide ARN and credentials
 

--- a/bridges/slack-confluent/README.md
+++ b/bridges/slack-confluent/README.md
@@ -11,7 +11,7 @@ This bridge uses
 - A Confluent Target instance.
 - A trigger that connects the broker with the target.
 
-## Parametrization
+## Parameterization
 
 Customization of Confluent's instance is required. Optionally the Slack source can also be customized to verify received messages signature.
 

--- a/bridges/slack-elastic/README.md
+++ b/bridges/slack-elastic/README.md
@@ -11,7 +11,7 @@ This bridge uses
 - A trigger that connects the broker with the target
 - An Elasticsearch target
 
-## Parametrization
+## Parameterization
 
 Customization of URL parameter and secret for Elasticsearch authentication are required.  Optionally the Slack source can also be customized to verify received messages signature.
 

--- a/bridges/sqs-sendgrid/README.md
+++ b/bridges/sqs-sendgrid/README.md
@@ -14,7 +14,7 @@ This bridge uses
 - A trigger that connects the SendGrid broker with the target
 - A Sendgrid target
 
-## Parametrization
+## Parameterization
 
 Customization of SQS and secret creation for SendGrid token is required.
 


### PR DESCRIPTION
Add 2 simple kafka bridges.

Note that:
- there is no target UI.
- these targets are using an unauthenticated kafka.
- production version kafka is not the staging tested version.

