### PR TITLE
Creates a Zendesk-Bumblebee-Comprehend-Bumblebee-Zendesk bridge

### DIFF
--- a/bridges/zendesk-bumblebee-zendesk/ed.yaml
+++ b/bridges/zendesk-bumblebee-zendesk/ed.yaml
@@ -1,0 +1,38 @@
+# Copyright (c) 2020 TriggerMesh Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This can be deployed as a development tool to view all of the events that are passed into the broker
+        apiVersion: serving.knative.dev/v1
+        kind: Service
+        metadata:
+          name: event-display
+        spec:
+          template:
+            spec:
+              containers:
+              - image: gcr.io/triggermesh/event_display-864884f202126ec3150c5fcef437d90c@sha256:5b0491983fa2019ab0fd7b8e5eaafb0bf9df3cf6fd4d1e4f10a34fcc6b59e858
+                name: user-container
+---
+
+      apiVersion: eventing.knative.dev/v1beta1
+      kind: Trigger
+      metadata:
+        name: ed-trigger
+      spec:
+        broker: events
+        subscriber:
+          ref:
+            apiVersion: serving.knative.dev/v1
+            kind: Service
+            name: event-display

--- a/bridges/zendesk-bumblebee-zendesk/secret.yaml
+++ b/bridges/zendesk-bumblebee-zendesk/secret.yaml
@@ -55,3 +55,4 @@ metadata:
 type: Opaque
 stringData:
   token:  '<ZENDESK API TOKEN>'
+  

--- a/bridges/zendesk-bumblebee-zendesk/secret.yaml
+++ b/bridges/zendesk-bumblebee-zendesk/secret.yaml
@@ -1,0 +1,57 @@
+# Copyright (c) 2020 TriggerMesh Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aws
+type: Opaque
+stringData:
+  AWS_ACCESS_KEY_ID: '<AWS ACCESS KEY ID>'
+  AWS_SECRET_ACCESS_KEY: '<AWS SECRET ACCESS KEY>'
+
+
+---
+
+# These are EXAMPLE secrets. Before deploying them, replace all of the placeholder values with valid data. 
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: zendesk-api
+type: Opaque
+stringData:
+  token:  '<ZENDESK API TOKEN>'
+  webhookPassword: '<ARBITRARY PASSWORD FOR BASIC AUTH>'
+---
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: zendesk-source
+type: Opaque
+stringData:
+  token:  '<ZENDESK API TOKEN>'
+  webhookPassword: '<ARBITRARY PASSWORD FOR BASIC AUTH>'
+
+---
+
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: zendesk-target
+type: Opaque
+stringData:
+  token:  '<ZENDESK API TOKEN>'

--- a/bridges/zendesk-bumblebee-zendesk/zendesk-bumblebee-zendesk.yaml
+++ b/bridges/zendesk-bumblebee-zendesk/zendesk-bumblebee-zendesk.yaml
@@ -197,3 +197,4 @@ spec:
           apiVersion: serving.knative.dev/v1
           kind: Service
           name: event-display
+          

--- a/bridges/zendesk-bumblebee-zendesk/zendesk-bumblebee-zendesk.yaml
+++ b/bridges/zendesk-bumblebee-zendesk/zendesk-bumblebee-zendesk.yaml
@@ -174,27 +174,3 @@ spec:
           apiVersion: targets.triggermesh.io/v1alpha1
           kind: ZendeskTarget
           name: tag-updater
-- object:
-    apiVersion: serving.knative.dev/v1
-    kind: Service
-    metadata:
-      name: event-display
-    spec:
-      template:
-        spec:
-          containers:
-          - image: gcr.io/triggermesh/event_display-864884f202126ec3150c5fcef437d90c@sha256:5b0491983fa2019ab0fd7b8e5eaafb0bf9df3cf6fd4d1e4f10a34fcc6b59e858
-            name: user-container
-- object:
-    apiVersion: eventing.knative.dev/v1beta1
-    kind: Trigger
-    metadata:
-      name: ed-trigger
-    spec:
-      broker: events
-      subscriber:
-        ref:
-          apiVersion: serving.knative.dev/v1
-          kind: Service
-          name: event-display
-          

--- a/bridges/zendesk-bumblebee-zendesk/zendesk-bumblebee-zendesk.yaml
+++ b/bridges/zendesk-bumblebee-zendesk/zendesk-bumblebee-zendesk.yaml
@@ -1,0 +1,199 @@
+# Copyright (c) 2020 TriggerMesh Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is an EXAMPLE Bridge. Before deploying it, replace all of the placeholder values with valid data. 
+apiVersion: flow.triggermesh.io/v1alpha1
+kind: Bridge
+metadata:
+    name: zendesk-bumblebee-zendesk
+    annotations:
+     bridges.triggermesh.io/name: zendesk-bumblebee-zendesk
+spec:
+  components:
+- object:
+    apiVersion: eventing.knative.dev/v1beta1
+    kind: Broker
+    metadata:
+      name: events
+- object:
+    apiVersion: sources.triggermesh.io/v1alpha1
+    kind: ZendeskSource
+    metadata:
+      name: zendesk
+    spec:
+      email: support@triggermesh.com
+      subdomain: triggermesh
+      webhookUsername: usr
+      token:
+        secretKeyRef:
+          name: zendesk-source
+          key: token
+      webhookPassword:
+        secretKeyRef:
+          name: zendesk-source
+          key: webhookPassword
+      sink:
+        ref:
+          apiVersion: eventing.knative.dev/v1beta1
+          kind: Broker
+          name: events
+- object:
+    apiVersion: flow.triggermesh.io/v1alpha1
+    kind: Transformation
+    metadata:
+      name: zendesk-comprehend
+    spec:
+      context:
+      - operation: add
+        paths:
+        - key: type 
+          value: io.triggermesh.awscomprehend.analyze
+      data:
+      - operation: store
+        paths: 
+        - key: $id
+          value: ticket.id
+        - key: $data
+          value: ticket.description
+      - operation: delete
+        paths:
+        - key:
+      - operation: add
+        paths:
+        - key: id
+          value: $id
+        - key: data
+          value: $data
+- object:
+    apiVersion: eventing.knative.dev/v1
+    kind: Trigger
+    metadata:
+      name: zendesk-comprehend
+    spec:
+      broker: events
+      filter:
+        attributes:
+          type: com.zendesk.ticket.created
+      subscriber:
+        ref:
+          apiVersion: flow.triggermesh.io/v1alpha1
+          kind: Transformation
+          name: zendesk-comprehend       
+- object:
+    apiVersion: targets.triggermesh.io/v1alpha1
+    kind: AWSComprehendTarget
+    metadata:
+      name: comprehend
+    spec:
+      region: us-east-1
+      language: en
+      awsApiKey:
+        secretKeyRef:
+          name: aws
+          key: AWS_ACCESS_KEY_ID
+      awsApiSecret:
+        secretKeyRef:
+          name: aws
+          key: AWS_SECRET_ACCESS_KEY
+- object:
+    apiVersion: eventing.knative.dev/v1beta1
+    kind: Trigger
+    metadata:
+      name: comprehend
+    spec:
+      broker: events
+      filter:
+        attributes:
+          type:  io.triggermesh.awscomprehend.analyze
+      subscriber:
+        ref:
+          apiVersion: targets.triggermesh.io/v1alpha1
+          kind: AWSComprehendTarget
+          name: comprehend
+- object:
+    apiVersion: flow.triggermesh.io/v1alpha1
+    kind: Transformation
+    metadata:
+      name: comprehend-zendesk 
+    spec:
+      context:
+      - operation: add
+        paths:
+        - key: type 
+          value: com.zendesk.tag.create
+- object:
+    apiVersion: eventing.knative.dev/v1
+    kind: Trigger
+    metadata:
+      name: comprehend-zendesk 
+    spec:
+      broker: events
+      filter:
+        attributes:
+          type: io.triggermesh.targets.aws.comprehend.result
+      subscriber:
+        ref:
+          apiVersion: flow.triggermesh.io/v1alpha1
+          kind: Transformation
+          name: comprehend-zendesk 
+- object:
+    apiVersion: targets.triggermesh.io/v1alpha1
+    kind: ZendeskTarget
+    metadata:
+     name: tag-updater
+    spec:
+      email: support@triggermesh.com
+      subdomain: triggermesh
+      token:
+       secretKeyRef:
+         name: zendesk-target
+         key: token
+- object:   
+    apiVersion: eventing.knative.dev/v1beta1
+    kind: Trigger
+    metadata:
+      name: zendesk
+    spec:
+      broker: events
+      filter:
+        attributes:
+          type: com.zendesk.tag.create
+      subscriber:
+        ref:
+          apiVersion: targets.triggermesh.io/v1alpha1
+          kind: ZendeskTarget
+          name: tag-updater
+- object:
+    apiVersion: serving.knative.dev/v1
+    kind: Service
+    metadata:
+      name: event-display
+    spec:
+      template:
+        spec:
+          containers:
+          - image: gcr.io/triggermesh/event_display-864884f202126ec3150c5fcef437d90c@sha256:5b0491983fa2019ab0fd7b8e5eaafb0bf9df3cf6fd4d1e4f10a34fcc6b59e858
+            name: user-container
+- object:
+    apiVersion: eventing.knative.dev/v1beta1
+    kind: Trigger
+    metadata:
+      name: ed-trigger
+    spec:
+      broker: events
+      subscriber:
+        ref:
+          apiVersion: serving.knative.dev/v1
+          kind: Service
+          name: event-display


### PR DESCRIPTION
This is confirmed working outside of the trigger flow controller. 

This bridge uses the AWS Comprehend Target found in this PR -> https://github.com/triggermesh/knative-targets/pull/316