### PR TITLE
Update oci-datadog metrics to support multimetric mode

### DIFF
--- a/bridges/oci-datadog/200-oci-datadog.yaml
+++ b/bridges/oci-datadog/200-oci-datadog.yaml
@@ -47,8 +47,10 @@ spec:
           oracleTenancy: ocid1.tenancy.oc1..aaaaaaaaswr
           oracleUser: ocid1.user.oc1..aaaaaaaaqloc
           oracleRegion: us-ashburn-1
-          metricsNamespace: oci_computeagent
-          metricsQuery: CpuUtilization[1m].mean()
+          metrics:
+          - name: cpuutilization
+            metricsNamespace: oci_computeagent
+            metricsQuery: CpuUtilization[1m].mean()
           metricsPollingFrequency: 1m
           sink:
             ref:

--- a/bridges/oci-datadog/translator/oci-datadog-trans.py
+++ b/bridges/oci-datadog/translator/oci-datadog-trans.py
@@ -21,6 +21,7 @@ def trans():
         headers['Ce-Id']=request.headers['Ce-Id']
         headers['Ce-Type']='io.triggermesh.datadog.metric.aggregated'
         headers['Ce-Source']=request.headers['Ce-Source'] + "/translated"
+        headers['Ce-Subject']=request.headers['Ce-Subject']
 
         # Modify the Oracle OCI Monitoring data to be usable for Datadog
         data = []


### PR DESCRIPTION
The PR https://github.com/triggermesh/event-sources/pull/173 updates the OCI Metrics Spec to support multiple entries which will require the bridge examples and demos to be updated to reflect the new world.

DO NOT MERGE UNTIL https://github.com/triggermesh/event-sources/pull/173 has been merged.