### PR TITLE
use upstream event-display image in all bridges

### DIFF
--- a/bridges/cronjob-display/cronjob-display.yaml
+++ b/bridges/cronjob-display/cronjob-display.yaml
@@ -36,7 +36,7 @@ spec:
           template:
             spec:
               containers:
-              - image: gcr.io/triggermesh/event_display-864884f202126ec3150c5fcef437d90c@sha256:5b0491983fa2019ab0fd7b8e5eaafb0bf9df3cf6fd4d1e4f10a34fcc6b59e858
+              - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display@sha256:a4c088d4e48eaac7dc6de0dc3ef3fa4ed3e8f224baa4c2937f11061d380df430
                 name: user-container
 
     - object:

--- a/bridges/github-bumblebee-twilio/ed.yaml
+++ b/bridges/github-bumblebee-twilio/ed.yaml
@@ -21,7 +21,7 @@
           template:
             spec:
               containers:
-              - image: gcr.io/triggermesh/event_display-864884f202126ec3150c5fcef437d90c@sha256:5b0491983fa2019ab0fd7b8e5eaafb0bf9df3cf6fd4d1e4f10a34fcc6b59e858
+              - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display@sha256:a4c088d4e48eaac7dc6de0dc3ef3fa4ed3e8f224baa4c2937f11061d380df430
                 name: user-container
 ---
 

--- a/bridges/github-display/github-display.yaml
+++ b/bridges/github-display/github-display.yaml
@@ -11,7 +11,7 @@ spec:
         kind: Broker
         metadata:
           name: github-default
-            
+
     - object:
         apiVersion: sources.knative.dev/v1alpha1
         kind: GitHubSource
@@ -34,7 +34,7 @@ spec:
               apiVersion: eventing.knative.dev/v1beta1
               kind: Broker
               name: github-default
-    
+
     - object:
         apiVersion: serving.knative.dev/v1
         kind: Service
@@ -44,7 +44,7 @@ spec:
           template:
             spec:
               containers:
-              - image: gcr.io/triggermesh/event_display-864884f202126ec3150c5fcef437d90c@sha256:5b0491983fa2019ab0fd7b8e5eaafb0bf9df3cf6fd4d1e4f10a34fcc6b59e858
+              - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display@sha256:a4c088d4e48eaac7dc6de0dc3ef3fa4ed3e8f224baa4c2937f11061d380df430
                 name: user-container
 
     - object:

--- a/bridges/gitlab/gitlab-display/gitlab-display.yaml
+++ b/bridges/gitlab/gitlab-display/gitlab-display.yaml
@@ -11,8 +11,8 @@ spec:
         kind: Broker
         metadata:
           name: gitlab-default
-            
-    - object: 
+
+    - object:
         apiVersion: sources.knative.dev/v1alpha1
         kind: GitLabSource
         metadata:
@@ -21,7 +21,7 @@ spec:
           eventTypes:
           - push_events
           - issues_events
-          projectUrl: https://gitlab.com/sebgoa/phoenix 
+          projectUrl: https://gitlab.com/sebgoa/phoenix
           accessToken:
             secretKeyRef:
               name: gitlabsecret
@@ -35,7 +35,7 @@ spec:
               apiVersion: eventing.knative.dev/v1beta1
               kind: Broker
               name: gitlab-default
-    
+
     - object:
         apiVersion: serving.knative.dev/v1
         kind: Service
@@ -45,7 +45,7 @@ spec:
           template:
             spec:
               containers:
-              - image: gcr.io/triggermesh/event_display-864884f202126ec3150c5fcef437d90c@sha256:5b0491983fa2019ab0fd7b8e5eaafb0bf9df3cf6fd4d1e4f10a34fcc6b59e858
+              - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display@sha256:a4c088d4e48eaac7dc6de0dc3ef3fa4ed3e8f224baa4c2937f11061d380df430
                 name: user-container
 
     - object:

--- a/bridges/kafka-display/kafka-display.yaml
+++ b/bridges/kafka-display/kafka-display.yaml
@@ -38,7 +38,7 @@ spec:
           template:
             spec:
               containers:
-              - image:  gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display@sha256:46d5a66f300c3ced590835d379a0e9badf413ae7ab60f21a2550ecedbc9eb9d3
+              - image:  gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display@sha256:a4c088d4e48eaac7dc6de0dc3ef3fa4ed3e8f224baa4c2937f11061d380df430
                 name: user-container
 
     - object:

--- a/bridges/oracle-oraclecloud/oracle-cloud-dumper.yaml
+++ b/bridges/oracle-oraclecloud/oracle-cloud-dumper.yaml
@@ -45,7 +45,7 @@ spec:
           template:
             spec:
               containers:
-              - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display
+              - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display@sha256:a4c088d4e48eaac7dc6de0dc3ef3fa4ed3e8f224baa4c2937f11061d380df430
                 name: user-container
 
     - object:

--- a/bridges/oracle-source/oracle-bridge-baseline.yaml
+++ b/bridges/oracle-source/oracle-bridge-baseline.yaml
@@ -38,7 +38,7 @@ spec:
           template:
             spec:
               containers:
-              - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display
+              - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display@sha256:a4c088d4e48eaac7dc6de0dc3ef3fa4ed3e8f224baa4c2937f11061d380df430
                 name: user-container
 
     - object:

--- a/bridges/oracle-source/oracle-bridge-slack-demo.yaml
+++ b/bridges/oracle-source/oracle-bridge-slack-demo.yaml
@@ -51,7 +51,7 @@ spec:
           template:
             spec:
               containers:
-              - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display
+              - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display@sha256:a4c088d4e48eaac7dc6de0dc3ef3fa4ed3e8f224baa4c2937f11061d380df430
                 name: user-container
 
     - object:

--- a/bridges/oracle-source/oracle-bridge-zendesk-demo.yaml
+++ b/bridges/oracle-source/oracle-bridge-zendesk-demo.yaml
@@ -51,7 +51,7 @@ spec:
           template:
             spec:
               containers:
-              - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display
+              - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display@sha256:a4c088d4e48eaac7dc6de0dc3ef3fa4ed3e8f224baa4c2937f11061d380df430
                 name: user-container
 
     - object:

--- a/bridges/p2p/nobroker.yaml
+++ b/bridges/p2p/nobroker.yaml
@@ -29,5 +29,5 @@ spec:
           template:
             spec:
               containers:
-              - image: gcr.io/triggermesh/event_display-864884f202126ec3150c5fcef437d90c@sha256:5b0491983fa2019ab0fd7b8e5eaafb0bf9df3cf6fd4d1e4f10a34fcc6b59e858
+              - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display@sha256:a4c088d4e48eaac7dc6de0dc3ef3fa4ed3e8f224baa4c2937f11061d380df430
                 name: user-container

--- a/bridges/slack-googlesheet/ed.yaml
+++ b/bridges/slack-googlesheet/ed.yaml
@@ -21,7 +21,7 @@ spec:
   template:
     spec:
       containers:
-      - image: gcr.io/triggermesh/event_display-864884f202126ec3150c5fcef437d90c@sha256:5b0491983fa2019ab0fd7b8e5eaafb0bf9df3cf6fd4d1e4f10a34fcc6b59e858
+      - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display@sha256:a4c088d4e48eaac7dc6de0dc3ef3fa4ed3e8f224baa4c2937f11061d380df430
         name: user-container
 ---
 

--- a/bridges/zendesk-sendgrid/ed.yaml
+++ b/bridges/zendesk-sendgrid/ed.yaml
@@ -21,7 +21,7 @@
           template:
             spec:
               containers:
-              - image: gcr.io/triggermesh/event_display-864884f202126ec3150c5fcef437d90c@sha256:5b0491983fa2019ab0fd7b8e5eaafb0bf9df3cf6fd4d1e4f10a34fcc6b59e858
+              - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display@sha256:a4c088d4e48eaac7dc6de0dc3ef3fa4ed3e8f224baa4c2937f11061d380df430
                 name: user-container
 ---
 


### PR DESCRIPTION
we noticed tests failing because the cluster was unable to pull the event-display image from GCR. This is the error listed in the ksvc describe

```console
Status:
  Conditions:
    Last Transition Time:        2021-05-10T04:40:47Z
    Message:                     Revision "event-display-00001" failed with message: Unable to fetch image "gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display": failed to resolve image to digest: GET https://gcr.io/v2/token?scope=repository%!A(MISSING)knative-releases%!F(MISSING)knative.dev%!F(MISSING)eventing-contrib%!F(MISSING)cmd%!F(MISSING)event_display%!A(MISSING)pull&service=gcr.io: unexpected status code 429 Too Many Requests: Quota Exceeded..
```

The quota is exceeded because of the api request to resolve the image digest. using the image digest instead of a tag fixes the issue